### PR TITLE
[setting]githubのissue作成用のテンプレートを作成しました。

### DIFF
--- a/.github/issue_template.yml
+++ b/.github/issue_template.yml
@@ -1,0 +1,44 @@
+name: 📘 ドキュメントベースIssue
+description: 概要・目的・完了条件ベースでIssueを作成するためのテンプレート
+title: "[Doc] "
+labels: ["documentation"]
+assignees: ["txoxu"]
+
+body:
+  - type: textarea
+    id: overview
+    attributes:
+      label: 🔖 概要
+      description: このIssueの概要を簡潔に記載してください。
+      placeholder: 例）画面ごとのコンポーネント設計を整理し、方針を統一する。
+    validations:
+      required: true
+
+  - type: textarea
+    id: purpose
+    attributes:
+      label: 🎯 目的
+      description: このIssueを通じて達成したい目的を記載してください。
+      placeholder: 例）開発の再利用性と効率性を高めるため。
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: done
+    attributes:
+      label: ✅ 完了条件
+      description: このIssueが完了と判断できる条件を明確にしてください。
+      options:
+        - label: 概要と目的が明確に記載されている
+        - label: 実装や議論に必要な前提情報が揃っている
+        - label: 関係者と合意が取れている
+        - label: 必要に応じて追加ドキュメントが作成されている
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 📝 備考（任意）
+      description: その他メモや関係リンクなどあれば記載してください。
+      placeholder: 例）関連IssueやFigma、NotionなどのURL
+    validations:
+      required: false


### PR DESCRIPTION
## 概要
- issueを作成しやすいようにテンプレートを.githubディレクトリに作成

## 変更内容
なし
## 動作確認

- [ ] 正常にissueテンプレートが反映されているか

## エビデンス

## issueチェックリスト
なし
## 関連issue
close
